### PR TITLE
create libgetopt.a

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -10,6 +10,8 @@ export ZOPEN_MAKE_OPTS="prefix=\$ZOPEN_INSTALL_DIR LIBCGETOPT=0 WITHOUT_GETTEXT=
 export ZOPEN_CHECK_OPTS="test"
 export ZOPEN_INSTALL_OPTS="install prefix=\$ZOPEN_INSTALL_DIR LIBCGETOPT=0 WITHOUT_GETTEXT=1"
 
+export ZOPEN_COMP="clang"
+
 zopen_check_results()
 {
   dir="$1"
@@ -24,7 +26,14 @@ zopen_check_results()
 
 zopen_append_to_env()
 {
-  # echo envars outside of PATH, MANPATH, LIBPATH
+cat <<ZZ
+if [ ! -z "\$ZOPEN_IN_ZOPEN_BUILD" ]; then
+  export ZOPEN_EXTRA_CFLAGS="\${ZOPEN_EXTRA_CFLAGS} -I\$PWD/include"
+  export ZOPEN_EXTRA_CXXFLAGS="\${ZOPEN_EXTRA_CXXFLAGS} -I\$PWD/include"
+  export ZOPEN_EXTRA_LDFLAGS="\${ZOPEN_EXTRA_LDFLAGS} -L\$PWD/lib"
+  export ZOPEN_EXTRA_LIBS="\${ZOPEN_EXTRA_LIBS} -lgetopt \$PWD/lib/libgetopt.a"
+fi
+ZZ
 }
 
 zopen_append_to_setup()

--- a/patches/Makefile.patch
+++ b/patches/Makefile.patch
@@ -1,9 +1,12 @@
 diff --git a/Makefile b/Makefile
-index ac9d1a4..54469fa 100644
+index ac9d1a4..727ac95 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -10,7 +10,7 @@ getoptdir=$(sharedir)/getopt
+@@ -8,9 +8,10 @@ man1dir=$(mandir)/man1
+ sharedir=$(prefix)/share
+ getoptdir=$(sharedir)/getopt
  localedir=$(sharedir)/locale
++libdir=$(prefix)/lib
  
  # Define this to 0 to use the getopt(3) routines in this package.
 -LIBCGETOPT=1
@@ -11,7 +14,12 @@ index ac9d1a4..54469fa 100644
  
  # Define this to 1 if you do not have the gettext routines
  WITHOUT_GETTEXT=0
-@@ -32,9 +32,9 @@ MSGFMT=msgfmt
+@@ -28,13 +29,14 @@ LD=ld
+ RM=rm -f
+ INSTALL=install
+ MSGFMT=msgfmt
++AR=ar
+ 
  LANGUAGES = ca cs da de es et eu fi fr gl hr hu id it ja nl pl pt_BR ru sl sv tr uk vi zh_CN zh_TW
  MOFILES:=$(patsubst %,po/%.mo,$(LANGUAGES))
  
@@ -23,3 +31,33 @@ index ac9d1a4..54469fa 100644
  endif
  WARNINGS=-Wall \
           -W -Wshadow -Wpointer-arith -Wbad-function-cast -Wcast-qual \
+@@ -54,19 +56,26 @@ objects=$(sources:.c=.o)
+ 
+ binaries=getopt
+ 
++archive_target=libgetopt.a
++archive_objects=$(objects)
++
++$(archive_target):	$(archive_objects)
++		$(AR) rcs $@ $(objects)
++
+ .PHONY: all clean realclean 
+-all: $(binaries) all_po
++all: $(binaries) $(archive_target) all_po
+ 
+ clean: clean_po
+-	-$(RM) $(objects) $(binaries) 
++	-$(RM) $(objects) $(binaries) $(archive_target)
+ 
+ getopt: $(objects)
+ 	$(CC) $(LDFLAGS) -o $@ $(objects)
+ 
+ install: getopt install_po
+-	$(INSTALL) -m 755 -d $(DESTDIR)$(bindir) $(DESTDIR)$(man1dir)
++	$(INSTALL) -m 755 -d $(DESTDIR)$(bindir) $(DESTDIR)$(man1dir) $(DESTDIR)$(libdir)
+ 	$(INSTALL) -m 755 getopt $(DESTDIR)$(bindir)
+ 	$(INSTALL) -m 644 getopt.1 $(DESTDIR)$(man1dir)
++	$(INSTALL) -m 644 libgetopt.a $(DESTDIR)$(libdir)
+ 
+ install_doc:
+ 	$(INSTALL) -m 755 -d $(DESTDIR)$(getoptdir)


### PR DESCRIPTION
Creating libgetopts.a from the objects file as other libraries such as avro has dependencies on getopts method. 